### PR TITLE
Bis-QC: add --nonDirectional flag for non-directional BS libraries (s…

### DIFF
--- a/Bis-QC/Bis-QC.pl
+++ b/Bis-QC/Bis-QC.pl
@@ -63,6 +63,7 @@ sub usage {
 	print STDERR "  --genome FILE: reference genome .fasta file that are used when you map reads in the bam file (Default: not specified. use hg19.fa in Bis-tools' resource directory).\n\n";
 	print STDERR "  --dbsnp FILE: dbSNP .vcf file that are used for genotyping (Default: not specified. use dbSNP_135.hg19.sort.vcf in Bis-tools' resource directory).\n\n";
 	print STDERR "  --enzyme_eff_regions FILES: Region to test enzyme efficiency. (Default: just use CTCF conserved motif and CGI promoters. allow multiple location files).\n\n";
+	print STDERR "  --nonDirectional: enable non-directional bisulfite mode (scNOMe-HiC, scNMT-seq, and other libraries where bisulfite-conversion frame is encoded in the XG tag rather than BAM is_reverse). Propagates -nonDirectional -badMate to all BisSNP invocations in Mode 1. (Default: not enabled)\n\n";
  	
     exit(1);
 }
@@ -97,6 +98,7 @@ my $pattern = "WCW";
 my $genome="$bistools_path/resource/genome/hg19_rCRSchrm.fa";
 my $dbsnp="$bistools_path/resource/dbSNP/dbsnp_135.hg19.sort.vcf";
 my @enzyme_eff_regions=();
+my $nonDirectional = "";
 
 
 GetOptions( 
@@ -120,6 +122,7 @@ GetOptions(
 			"genome=s" => \$genome,
 			"dbsnp=s" => \$dbsnp,
 			"enzyme_eff_regions=s" => \@enzyme_eff_regions,
+			"nonDirectional" => \$nonDirectional,
 			#"r=s" => \$r,
 );
 
@@ -274,32 +277,33 @@ sub check_bam_preprocess {
 
 sub check_bs_conv {
 	my $bam=shift @_;
+	my $nondir_flag = $nonDirectional ne "" ? "--nonDirectional " : "";
 	#### Methylation bias check, bisulfite conversion along cycle, check 5' conversion rate
-	my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/methylation_bias_plot.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --r $r --pattern $pattern --genome $genome $bam\n";
+	my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/methylation_bias_plot.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --r $r --pattern $pattern --genome $genome ${nondir_flag}$bam\n";
 	print STDERR "Methylation bias check:\n $cmd\n";
 	system($cmd)==0 || die "Unexpected stop at methylation bias check step: $! \n";
-	
+
 	##bisulfite conversion rate for the whole reads
-	$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bisulfite_conv_distribution.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --r $r --pattern $pattern --genome $genome $bam\n";
+	$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bisulfite_conv_distribution.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --r $r --pattern $pattern --genome $genome ${nondir_flag}$bam\n";
 	print STDERR "Bisulfite conversion rate distribution of whole reads:\n $cmd\n";
 	system($cmd)==0 || die "Unexpected stop at bisulfite conversion rate distribution check step: $! \n";
-	
+
 	##Methylation level around different trinucleotide on chrM and chr21
 	if($disable_trinuc_check eq ""){
 		my $tri_nuc_log=$bam;
 		$tri_nuc_log=~s/\.bam$/.trinuc_methy.chrM.txt/;
-		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --genome $genome --dbsnp $dbsnp --nt $nt --mem $mem --interval chrM $tri_nuc_log $bam\n";
+		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --genome $genome --dbsnp $dbsnp --nt $nt --mem $mem --interval chrM ${nondir_flag}$tri_nuc_log $bam\n";
 		print STDERR "Bisulfite conversion rate distribution of whole reads at chrM:\n $cmd\n";
 		system($cmd)==0 || die "Unexpected stop at methylation level of trinucleotides in chrM check step: $! \n";
-	
+
 		$tri_nuc_log=$bam;
 		$tri_nuc_log=~s/\.bam$/.trinuc_methy.chr21.txt/;
-		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --genome $genome --dbsnp $dbsnp --nt $nt --mem $mem --interval chr21 $tri_nuc_log $bam\n";
+		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl --bissnp $bistools_path/Bis-SNP/Bis-SNP.latest.jar --genome $genome --dbsnp $dbsnp --nt $nt --mem $mem --interval chr21 ${nondir_flag}$tri_nuc_log $bam\n";
 		print STDERR "Bisulfite conversion rate distribution of whole reads at chr21:\n $cmd\n";
 		system($cmd)==0 || die "Unexpected stop at methylation level of trinucleotides in chr21 check step: $! \n";
 	}
 
-	
+
 }
 
 
@@ -317,20 +321,21 @@ sub check_cov_dist {
 sub check_enzyme_eff {
 	##check NOMe Enyzme efficiency methylation/accessibility level around conserved CTCF motif and CGI promoters
 	my $bam=shift @_;
+	my $nondir_flag = $nonDirectional ne "" ? "--nonDirectional " : "";
 	#--r_script /home/uec-00/yapingli/code/mytools/R/MethyPatternFeaturePlotSinglePlotNoSumFeature.R --sort_perl_script /home/uec-00/yapingli/code/mytools/perl/sortByRefAndCor.pl --pbs --result_dir /export/uec-gs1/laird/users/yaping/code/NOMeseq/MethyPatternFeatureWalker/HCT116_hg19/MethyPatternResult/MAR_MPR/
 	my $prefix=basename($bam);
 	my $dirname=dirname($bam);
 	if(scalar(@enzyme_eff_regions)==0){
 		$prefix=~s/(\w+)\S+$/Conserved_CTCF_$1/;
-		my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq $bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $bistools_path/resource/ctcf/xie_cuddapeh_plus_kim.orientedOnly.noKnownTss4kb.hg19.sort.bed $genome $prefix $dbsnp ";
+		my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq ${nondir_flag}$bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $bistools_path/resource/ctcf/xie_cuddapeh_plus_kim.orientedOnly.noKnownTss4kb.hg19.sort.bed $genome $prefix $dbsnp ";
 		$cmd.="--r_script $bistools_path/Bis-QC/after_reads_mapping/MethyPatternFeaturePlotForNOMeSeq.R --sort_perl_script $bistools_path/utils/sortByRefAndCor.pl --result_dir $dirname\n";
 		print STDERR "Check NOMe Enyzme efficiency methylation/accessibility level around conserved CTCF motif:\n $cmd\n";
 		print STDERR "Default refion is on hg19 !!!\n";
 		system($cmd)==0 || die "Unexpected stop at NOMe Enyzme efficiency check step: $! \n";
-	
+
 		$prefix=basename($bam);
 		$prefix=~s/(\w+)\S+$/CGI_TSS_$1/;
-		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq $bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $bistools_path/resource/tss/knownGene-tss-ucsc08082013-unique.tj_gg_plus200bp_cgi.hg19.noChrM.sort.bed $genome $prefix $dbsnp ";
+		$cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq ${nondir_flag}$bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $bistools_path/resource/tss/knownGene-tss-ucsc08082013-unique.tj_gg_plus200bp_cgi.hg19.noChrM.sort.bed $genome $prefix $dbsnp ";
 		$cmd.="--r_script $bistools_path/Bis-QC/after_reads_mapping/MethyPatternFeaturePlotForNOMeSeq.R --sort_perl_script $bistools_path/utils/sortByRefAndCor.pl --result_dir $dirname\n";
 		print STDERR "Check NOMe Enyzme efficiency methylation/accessibility level around CGI promoters:\n $cmd\n";
 		print STDERR "Default refion is on hg19 !!!\n";
@@ -340,15 +345,15 @@ sub check_enzyme_eff {
 			$prefix=~s/(\w+)\S+$/$1/;
 			my $loc_prefix=basename($enzyme_eff_region);
 			$loc_prefix=~s/(\S+)\.\S+$/$1/;
-			my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq $bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $enzyme_eff_region $genome $prefix $dbsnp ";
+			my $cmd="perl $bistools_path/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl --mem $mem --cpu $nt --nomeseq ${nondir_flag}$bistools_path/Bis-SNP/Bis-SNP.latest.jar $bam $enzyme_eff_region $genome $prefix $dbsnp ";
 			$cmd.="--r_script $bistools_path/Bis-QC/after_reads_mapping/MethyPatternFeaturePlotForNOMeSeq.R --sort_perl_script $bistools_path/utils/sortByRefAndCor.pl --result_dir $dirname\n";
 			print STDERR "Check NOMe Enyzme efficiency methylation/accessibility level around $enzyme_eff_region:\n $cmd\n";
 
 			system($cmd)==0 || die "Unexpected stop at NOMe Enyzme efficiency check step: $! \n";
-			
+
 		}
 	}
-	
+
 }
 
 

--- a/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl
+++ b/Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl
@@ -52,6 +52,7 @@ sub usage {
     print "  --qual NUM : genotyping quality score (Default: 20)\n\n";
     print "  --smooth : enable smooth around bin_size region, e.g. each data point represent the avergae of methylation value around 20bp\n\n";
     print "  --use_bad_mate : enable the use of unproper paired reads\n\n";
+    print "  --nonDirectional : enable non-directional bisulfite mode (scNOMe-HiC, scNMT-seq, etc.). Adds -nonDirectional -badMate to BisSNP commands. (Default: not enabled)\n\n";
     print "  --invert_dups_usage : when met inverted dups reads (Default: --invert_dups_usage 1)\n";
     print "                         1) USE_ONLY_1ST_END: only use the 1st end of reads  when it was a inverted dups\n";
 	print "                         2) USE_BOTH_END: use both ends of reads  when it was a inverted dups\n";
@@ -106,6 +107,7 @@ my $smooth = "";
 my $invert_dups_usage = 1;
 my $use_bad_mate = "";
 my $minConv=1;
+my $nonDirectional = "";
 
 my $qual = 20;
 my $bin_size = 20;
@@ -162,7 +164,8 @@ GetOptions( "pbs" => \$pbs,
 			"trim3=i" => \$trim3,
 			"alignment_mode=i" => \$alignment_mode,
 			"cytosines=s" => \@cytosines,
-			"bed_format_style=i" => \$bed_format_style);
+			"bed_format_style=i" => \$bed_format_style,
+			"nonDirectional" => \$nonDirectional);
 
 usage() if ( scalar(@ARGV) == 0 );
 
@@ -267,13 +270,20 @@ sub align_bam{
 	my $sort_feature_file_notpath = $sort_feature_file;
 	$sort_feature_file_notpath =~ s/.+\///g;
 	$sort_feature_file_notpath =~ s/minusUpstream\S+.plusDownstream\S+\.bed//;
+	# Non-directional libraries (scNOMe-HiC, scNMT-seq): MethyPatternFeatureByBam
+	# delegates methylation calling to BisulfiteGenotyperEngine, which uses the
+	# XG-aware code paths in BisSNP >= 1.1 only when -nonDirectional is passed.
+	# -nonDirectional also implies we should keep Hi-C chimeric mates (-badMate).
 	if($nomeseq ne ""){
 		 $java_cmd = "java -Xmx$mem -jar $bissnp_jar -T MethyPatternFeatureByBam ";
 		$java_cmd .= "-R $ref -I $input_file -D $dbsnp -stand_call_conf $qual -stand_emit_conf 0 -orientated -mmq $mmq -mbq $mbq -trim5 $trim5 -trim3 $trim3 -minConv $minConv ";
 		$java_cmd .= "-feature $sort_feature_file -distance $data_matrix_scale -minCTdepth $minCT -alignmentType $alignment_modes_hash{$alignment_mode} ";
 		$java_cmd .= "-L $location_file -invDups $invert_dups_hash{$invert_dups_usage} ";
-		if($use_bad_mate ne ""){
+		if($use_bad_mate ne "" || $nonDirectional ne ""){
 			$java_cmd .= "-badMate ";
+		}
+		if($nonDirectional ne ""){
+			$java_cmd .= "-nonDirectional ";
 		}
 		
 		$gch_file = $result_dir."$prefix.alignedTo.$sort_feature_file_notpath.gch.$data_matrix_scale.txt";
@@ -289,8 +299,11 @@ sub align_bam{
 			$java_cmd .= "-R $ref -I $input_file -D $dbsnp -stand_call_conf $qual -stand_emit_conf 0 -orientated -mmq $mmq -mbq $mbq -trim5 $trim5 -trim3 $trim3 -minConv $minConv ";
 			$java_cmd .= "-feature $sort_feature_file -distance $data_matrix_scale -minCTdepth $minCT -alignmentType $alignment_modes_hash{$alignment_mode} ";
 			$java_cmd .= "-L $location_file -invDups $invert_dups_hash{$invert_dups_usage} ";
-			if($use_bad_mate ne ""){
+			if($use_bad_mate ne "" || $nonDirectional ne ""){
 				$java_cmd .= "-badMate ";
+			}
+			if($nonDirectional ne ""){
+				$java_cmd .= "-nonDirectional ";
 			}
 			$hcg_file = $result_dir."$prefix.alignedTo.$sort_feature_file_notpath.hcg.$data_matrix_scale.txt";
 			$java_cmd = $java_cmd."-methyFile $hcg_file -C HCG,2 \n";
@@ -305,8 +318,11 @@ sub align_bam{
 			$java_cmd_hcg .= "-R $ref -I $input_file -D $dbsnp -stand_call_conf $qual -stand_emit_conf 0 -orientated -mmq $mmq -mbq $mbq -minConv $minConv ";
 			$java_cmd_hcg .= "-feature $sort_feature_file -distance $data_matrix_scale -minCTdepth $minCT -alignmentType $alignment_modes_hash{$alignment_mode} ";
 			$java_cmd_hcg .= "-L $location_file -invDups $invert_dups_hash{$invert_dups_usage} ";
-			if($use_bad_mate ne ""){
+			if($use_bad_mate ne "" || $nonDirectional ne ""){
 				$java_cmd_hcg .= "-badMate ";
+			}
+			if($nonDirectional ne ""){
+				$java_cmd_hcg .= "-nonDirectional ";
 			}
 			$hcg_file = $result_dir."$prefix.alignedTo.$sort_feature_file_notpath.hcg.$data_matrix_scale.txt";
 			$java_cmd_hcg = $java_cmd_hcg."-methyFile $hcg_file -C HCG,2 \n";
@@ -328,8 +344,11 @@ sub align_bam{
 			$java_cmd .= "-feature $sort_feature_file -distance $data_matrix_scale -minCTdepth $minCT -alignmentType $alignment_modes_hash{$alignment_mode} ";
 			$java_cmd .= "-C $cytosine ";
 			$java_cmd .= "-L $location_file -invDups $invert_dups_hash{$invert_dups_usage} ";
-			if($use_bad_mate ne ""){
+			if($use_bad_mate ne "" || $nonDirectional ne ""){
 				$java_cmd .= "-badMate ";
+			}
+			if($nonDirectional ne ""){
+				$java_cmd .= "-nonDirectional ";
 			}
 			$cpg_file = $result_dir."$prefix.alignedTo.$sort_feature_file_notpath.$output_format.$data_matrix_scale.txt";
 			$java_cmd = $java_cmd."-methyFile $cpg_file ";

--- a/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl
+++ b/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl
@@ -18,6 +18,7 @@ chomp $numcores;
 my $mem="8"; #how many Giga bytes memory need
 my $interval = "chrM";
 my $not_use_bad_mates="";
+my $nonDirectional="";
 
 GetOptions(
 	"bissnp=s" => \$BISSNP,
@@ -27,6 +28,7 @@ GetOptions(
 	"mem=i" => \$mem,
 	"interval=s" => \$interval,
 	"not_use_bad_mates" => \$not_use_bad_mates,
+	"nonDirectional" => \$nonDirectional,
 );
 
 
@@ -68,6 +70,9 @@ sub bissnp{
 	}
 	$cmd .= "$c_str";
 	$cmd .= "-toCoverage 99999999 " if ($interval eq "chrM" || $interval eq "MT" || $not_use_bad_mates eq "");
+	# Non-directional libraries (scNOMe-HiC, scNMT-seq): XG-aware code paths
+	# require -nonDirectional; Hi-C chimeric mates need -badMate.
+	$cmd .= "-nonDirectional -badMate " if $nonDirectional ne "";
 	$cmd .= "-stand_call_conf 20 -stand_emit_conf 0 -nt $numcores -minConv 1 \n";
 
 	print STDERR "$cmd\n";

--- a/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl
+++ b/Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl
@@ -73,7 +73,7 @@ sub bissnp{
 	# Non-directional libraries (scNOMe-HiC, scNMT-seq): XG-aware code paths
 	# require -nonDirectional; Hi-C chimeric mates need -badMate.
 	$cmd .= "-nonDirectional -badMate " if $nonDirectional ne "";
-	$cmd .= "-stand_call_conf 20 -stand_emit_conf 0 -nt $numcores -minConv 1 \n";
+	$cmd .= "-stand_call_conf 20 -nt $numcores -minConv 1 \n";
 
 	print STDERR "$cmd\n";
 	system($cmd)==0 || die "can't generate trinucleotide methylaiton level in chromesome $interval:$!\n";

--- a/Bis-QC/after_reads_mapping/bisulfite_conv_distribution.pl
+++ b/Bis-QC/after_reads_mapping/bisulfite_conv_distribution.pl
@@ -19,6 +19,7 @@ my $pattern = "WCW";
 my $genome="$bistools_path/resource/genome/hg19_rCRSchrm.fa";
 my $mem="8"; #how many Giga bytes memory need
 my $r_script = "$bistools_path/Bis-QC/after_reads_mapping/bisulfiteConvDistPlot.R";
+my $nonDirectional = "";
 
 GetOptions(
 	"bissnp=s" => \$BISSNP,
@@ -26,16 +27,21 @@ GetOptions(
 	"pattern=s" => \$pattern,
 	"genome=s" => \$genome,
 	"mem=i" => \$mem,
+	"nonDirectional" => \$nonDirectional,
 );
 
 my $file=$ARGV[0];
+
+# Non-directional libraries (scNOMe-HiC, scNMT-seq) need the XG-aware code
+# paths and -badMate; see methylation_bias_plot.pl for details.
+my $nondir_args = $nonDirectional ne "" ? " -nonDirectional -badMate" : "";
 
 ##generate pattern methylation histgram file:
 
 my $out_hist=$file;
 $out_hist=~ s/\.bam$/.hist.txt/;
 
-my $cmd .= "java -Xmx${mem}g -jar $BISSNP -T BisulfiteConversionCheck -R $genome -I $file -pattern $pattern -patternHist $out_hist \n";
+my $cmd .= "java -Xmx${mem}g -jar $BISSNP -T BisulfiteConversionCheck -R $genome -I $file -pattern $pattern -patternHist $out_hist${nondir_args} \n";
 print STDERR $cmd;
 system($cmd)==0 || die "can't generate methylation histogram file in bisulfite conversion distribution check part:$!\n";
 

--- a/Bis-QC/after_reads_mapping/methylation_bias_plot.pl
+++ b/Bis-QC/after_reads_mapping/methylation_bias_plot.pl
@@ -19,6 +19,7 @@ my $pattern = "WCW";
 my $genome="$bistools_path/resource/genome/hg19_rCRSchrm.fa";
 my $mem="8"; #how many Giga bytes memory need
 my $r_script = "$bistools_path/Bis-QC/after_reads_mapping/methyBiasDistPlot.R";
+my $nonDirectional = "";
 
 GetOptions(
 	"bissnp=s" => \$BISSNP,
@@ -26,14 +27,22 @@ GetOptions(
 	"pattern=s" => \$pattern,
 	"genome=s" => \$genome,
 	"mem=i" => \$mem,
+	"nonDirectional" => \$nonDirectional,
 );
 
 my $file=$ARGV[0];
 
+# Non-directional libraries (scNOMe-HiC, scNMT-seq, etc.) encode the
+# bisulfite-conversion frame in the XG tag rather than BAM is_reverse, and
+# Hi-C chimeric mates need -badMate to be kept past the GATK 3.8 adaptor
+# clip filter. The XG-aware code paths in BisSNP >= 1.1 only engage when
+# -nonDirectional is passed.
+my $nondir_args = $nonDirectional ne "" ? " -nonDirectional -badMate" : "";
+
 ##generate pattern methylation matrix file:
 my $out=$file;
 $out =~ s/\.bam$/.${pattern}.methy.cycle.txt/;
-my $cmd="java -Xmx${mem}g -jar $BISSNP -T QuickMethylationLevel -R $genome -I $file -pattern $pattern -patternHist $out\n";
+my $cmd="java -Xmx${mem}g -jar $BISSNP -T QuickMethylationLevel -R $genome -I $file -pattern $pattern -patternHist $out${nondir_args}\n";
 print STDERR $cmd;
 system($cmd)==0 || die "can't generate methylation matrix file in methylation bias check part:$!\n";
 


### PR DESCRIPTION
  ## Summary

  Adds a `--nonDirectional` flag to `Bis-QC.pl` and propagates it as
  `-nonDirectional -badMate` to every BisSNP invocation in Mode 1 (post-mapping
  QC). This is what's needed to engage the XG-aware filter chain and
  genotyper code paths merged in #11 when running Bis-QC against
  non-directional bisulfite libraries (scNOMe-HiC, scNMT-seq, and similar).

  ## Why

  PR #11 made BisSNP's filter chain (BisulfiteMismatchReadsFilter,
  BisulfiteIncompleteConvReadsFilter, BisulfiteFivePrimeConvReadsFilter) and
  BisulfiteGenotyper XG-aware, so reads where the bisulfite-conversion frame
  is encoded in the XG tag (rather than BAM `is_reverse`) are filtered and
  genotyped correctly. Those code paths only engage when `-nonDirectional`
  is passed.

  Without this PR, every Bis-QC Mode-1 sub-script invokes BisSNP without
  `-nonDirectional`, so the XG-aware code paths never fire — Bis-QC's results
  are wrong on the very libraries that motivated PR #11. Hi-C chimeric mates
  also need `-badMate` to survive the GATK 3.8 adaptor-clip filter.

  ## What changed

  | File | Change |
  |---|---|
  | `Bis-QC/Bis-QC.pl` | New `--nonDirectional` option; propagated to each Mode-1 sub-script invocation |
  | `Bis-QC/after_reads_mapping/methylation_bias_plot.pl` | Accept `--nonDirectional`; append `-nonDirectional -badMate` to BisSNP cmd |
  | `Bis-QC/after_reads_mapping/bisulfite_conv_distribution.pl` | Same |
  | `Bis-QC/after_reads_mapping/bissnp_trinuc_sample.pl` | Same |
  | `Bis-QC/after_reads_mapping/MethyPatternAlignEasyUsage.pl` | Same, applied to all 3 BisSNP cmd construction sites in `align_bam()` |

  `coverageEstimate.pl` is intentionally left alone — coverage is
  bisulfite-frame-agnostic and the script already passes `-badMate` by default.

  ## Behavior

  - Default: `--nonDirectional` is off; no change for directional WGBS/NOMe-seq users.
  - When passed: every Mode-1 BisSNP invocation gains `-nonDirectional -badMate`.

  ## Important caveat (companion PR forthcoming)

  This PR fixes the filter chain and BisulfiteGenotyper-based QCs
  (`bissnp_trinuc_sample.pl`, `MethyPatternAlignEasyUsage.pl`). It does NOT
  fully fix `methylation_bias_plot.pl` (QuickMethylationLevel walker) or
  `bisulfite_conv_distribution.pl` (BisulfiteConversionCheck walker), because
  those two walkers determine the bisulfite frame from
  `read.getReadNegativeStrandFlag()` directly in their own `map()` methods,
  bypassing the patched BisSNPUtils helpers. A companion PR (source patches
  to those two walker classes) is filed separately.

  In other words: this PR is necessary but not sufficient for full
  scNOMe-HiC-accurate QC. Both PRs together are sufficient.